### PR TITLE
Add minitest-focus

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :test, :development do
   gem "ffaker"
   gem "sqlite3"
   gem "pry"
+  gem "minitest-focus"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
     mime-types-data (3.2016.0221)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
+    minitest-focus (1.1.2)
+      minitest (>= 4, < 6)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     orm_adapter (0.5.0)
@@ -204,6 +206,7 @@ DEPENDENCIES
   font-awesome-rails
   jquery-rails
   kaminari
+  minitest-focus
   pg
   pry
   pry-rails


### PR DESCRIPTION
So we can focus on one test at a time. To use, just add `focus` above the test you want to isolate.
