### PR TITLE
create an interaction with a person

### DIFF
--- a/app/controllers/interactions_controller.rb
+++ b/app/controllers/interactions_controller.rb
@@ -4,7 +4,10 @@ class InteractionsController < ApplicationController
   # GET /interactions
   # GET /interactions.json
   def index
-    @interactions = Interaction.all.order(created_at: :desc).page(params[:page])
+    @interactions = Interaction.all.order(created_at: :desc).page(params[:page]).where(user_id: current_user.id)
+    if current_user.is_a_boss
+      @interactions = Interaction.all.order(created_at: :desc).page(params[:page])
+    end
 
     respond_to do |format|
       format.html # index.html.erb

--- a/app/views/interactions/_form.html.erb
+++ b/app/views/interactions/_form.html.erb
@@ -27,6 +27,18 @@
     <%= f.label :follow_up_date %><br>
     <%= f.datetime_select :follow_up_date, as: :datepicker %>
   </div>
+  <div class="field">
+    <%= f.label :person %><br>
+    <%= f.select(
+      :person_id,
+      options_from_collection_for_select(
+      Person.all,
+      :id,
+      :first_name
+      )
+    ) %>
+  </div>
+
   <br>
   <div class="actions">
     <%= f.submit class: "btn btn-success" %>

--- a/app/views/interactions/_interaction.html.erb
+++ b/app/views/interactions/_interaction.html.erb
@@ -23,6 +23,13 @@
       <strong>Follow up date:</strong>
       <%= interaction.follow_up_date.strftime("%m/%d/%y") %>
     </p>
+
+    <p><strong>Contact: </strong>
+      <%= link_to "#{interaction.person.first_name} #{interaction.person.last_name}", person_path(interaction.person_id) %>
+      <strong>, By: </strong>
+      <%= link_to "#{interaction.user.first_name} #{interaction.user.last_name}", user_path(interaction.user_id) %>
+    </p>
+
       <%= link_to fa_icon('pencil', text: 'Edit'), edit_interaction_path(interaction), class: 'btn btn-sm btn-default' %>
       <%= link_to fa_icon('trash-o', text: 'Destroy'), interaction, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-sm btn-danger' %>
 <hr>

--- a/app/views/interactions/show.html.erb
+++ b/app/views/interactions/show.html.erb
@@ -20,6 +20,10 @@
   <%= @interaction.follow_up_date %>
 </p>
 
+<p><strong>Contact: </strong>
+  <%= link_to @interaction.person.first_name, person_path(@interaction.person_id) %>
+</p>
+
 <br>
 <%= link_to fa_icon('pencil', text: 'Edit'), edit_interaction_path(@interaction), class: 'btn btn-sm btn-default' %>
 <%= link_to fa_icon('chevron-left', text: 'Back'), interactions_path, class: 'btn btn-sm btn-default' %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -32,7 +32,7 @@ end
 
 100.times do |ct|
   ct = ["Cell", "Work", "Home"]
-  PhoneNumber.create(number: FFaker::PhoneNumber.phone_number, phone_numberable_id: rand(1..50), phone_numberable_type: "Person", number_type: ct[rand(0..2)])
+  PhoneNumber.create(number: FFaker::PhoneNumber.short_phone_number, phone_numberable_id: rand(1..50), phone_numberable_type: "Person", number_type: ct[rand(0..2)])
 end
 
 100.times do
@@ -45,7 +45,7 @@ end
 
 25.times do |ct|
   ct = ["Cell", "Work", "Home"]
-  PhoneNumber.create(number: FFaker::PhoneNumber.phone_number, phone_numberable_id: rand(1..25), phone_numberable_type: "Company", number_type: ct[rand(0..2)])
+  PhoneNumber.create(number: FFaker::PhoneNumber.short_phone_number, phone_numberable_id: rand(1..25), phone_numberable_type: "Company", number_type: ct[rand(0..2)])
 end
 
 25.times do


### PR DESCRIPTION
/interactions#index now shows only the current user's interactions, if you are a boss/admin you can still see all of them.

We divided person in first/last name and select drop down menu only shows one column

Interaction shows one more field of data, the person/contact, with a link going to that person's page with all their info.

changed seed data from phone_number to short_phone_number because it is much simplier and easy to read
